### PR TITLE
feat: use flyyer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7'
+ruby '2.7.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.0'
@@ -53,6 +53,10 @@ gem 'icalendar'
 
 # CORS Middleware
 gem 'rack-cors'
+
+gem 'flyyer'
+gem 'jwt'
+gem 'meta-tags'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    flyyer (2.0.0)
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.7.0)
@@ -143,6 +144,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jwt (2.2.3)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -171,6 +173,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
+    meta-tags (2.15.0)
+      actionpack (>= 3.2.0, < 6.2)
     method_source (1.0.0)
     mini_mime (1.1.0)
     minitest (5.14.4)
@@ -345,6 +349,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -357,10 +362,13 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  flyyer
   http
   icalendar
   jbuilder (~> 2.7)
+  jwt
   listen (~> 3.3)
+  meta-tags
   nokogiri
   pg (~> 1.1)
   puma (~> 5.0)
@@ -383,7 +391,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.2.14
+   2.2.24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     bcrypt (3.1.16)
     benchmark (0.1.1)
     bindex (0.8.1)
-    bootsnap (1.7.6)
+    bootsnap (1.7.7)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -114,7 +114,7 @@ GEM
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.7.0)
-    globalid (0.5.1)
+    globalid (0.5.2)
       activesupport (>= 5.0)
     has_scope (0.8.0)
       actionpack (>= 5.2)
@@ -177,10 +177,12 @@ GEM
       actionpack (>= 3.2.0, < 6.2)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
-    nio4r (2.5.7)
-    nokogiri (1.11.7-x86_64-linux)
+    nio4r (2.5.8)
+    nokogiri (1.12.2)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
@@ -267,7 +269,7 @@ GEM
       rubocop-ast (>= 1.8.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.8.0)
+    rubocop-ast (1.9.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.11.4)
       rubocop (>= 1.7.0, < 2.0)
@@ -350,7 +352,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   activeadmin
@@ -391,7 +392,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.24
+   2.1.4

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -158,7 +158,6 @@ class ScheduleController < ApplicationController
       f.variables = { courses: @courses.map(&:schedule_json) }
     end
     image_src = flyyer.href.html_safe
-    ap image_src
     social_image = { _: image_src }
     set_meta_tags image_src: image_src, og: { image: social_image }, twitter: { image: social_image }
   end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -155,37 +155,37 @@ class ScheduleController < ApplicationController
     flyyer = Flyyer::Flyyer.create do |f|
       f.project = 'ucalendar'
       f.path = request.path
-      f.variables = { courses: @courses.map(&:schedule_json) }
+      f.variables = { _: @courses.map(&:schedule_min_json) }
     end
     image_src = flyyer.href.html_safe
     social_image = { _: image_src }
 
-    title = "UCalendar"
+    title = 'UCalendar'
 
-    description = if (@term.nil? || @courses.empty?)
+    description = if @term.nil? || @courses.empty?
                     I18n.t('page_description')
                   else
                     I18n.t('schedule_of', subjects_names: @courses.map(&:subject).map(&:name).to_sentence)
                   end
 
     set_meta_tags({
-      site: title,
-      description: description,
-      image_src: image_src,
-      og: {
-        image: social_image,
-        title: title,
-        type: "website",
-        url: request.host,
-      },
-      twitter: {
-        image: social_image,
-        card: description,
-      },
-      flyyer: {
-        default: ActionController::Base.helpers.asset_path('logo.png'),
-        color: 'indigo',
-      },
-    })
+                    site: title,
+                    description: description,
+                    image_src: image_src,
+                    og: {
+                      image: social_image,
+                      title: title,
+                      type: 'website',
+                      url: request.host,
+                    },
+                    twitter: {
+                      image: social_image,
+                      card: description,
+                    },
+                    flyyer: {
+                      default: ActionController::Base.helpers.asset_path('logo.png'),
+                      color: 'indigo',
+                    },
+                  })
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -7,7 +7,7 @@ require_relative '../lib/buscacursos_scraper'
 class ScheduleController < ApplicationController
   before_action :find_term, only: :show
   before_action :find_courses, only: :show
-  before_action :set_flyyer, only: :show
+  before_action :meta, only: :show
 
   def show
     respond_to do |format|
@@ -151,7 +151,7 @@ class ScheduleController < ApplicationController
     # BuscacursosScraper.instance.get_exams(courses.map(&:to_s), @term.period, @term.year)
   end
 
-  def set_flyyer
+  def meta
     flyyer = Flyyer::Flyyer.create do |f|
       f.project = 'ucalendar'
       f.path = request.path
@@ -159,6 +159,33 @@ class ScheduleController < ApplicationController
     end
     image_src = flyyer.href.html_safe
     social_image = { _: image_src }
-    set_meta_tags image_src: image_src, og: { image: social_image }, twitter: { image: social_image }
+
+    title = "UCalendar"
+
+    description = if (@term.nil? || @courses.empty?)
+                    I18n.t('page_description')
+                  else
+                    I18n.t('schedule_of', subjects_names: @courses.map(&:subject).map(&:name).to_sentence)
+                  end
+
+    set_meta_tags({
+      site: title,
+      description: description,
+      image_src: image_src,
+      og: {
+        image: social_image,
+        title: title,
+        type: "website",
+        url: request.host,
+      },
+      twitter: {
+        image: social_image,
+        card: description,
+      },
+      flyyer: {
+        default: ActionController::Base.helpers.asset_path('logo.png'),
+        color: 'indigo',
+      },
+    })
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,7 +18,7 @@ class Course < ApplicationRecord
     "#{subject.code}-#{section}"
   end
 
-  def schedule_json
-    { code: display_name, modules: schedule.schedule_events.map(&:schedule_json) }
+  def schedule_min_json
+    { c: display_name, _: schedule.schedule_events.map(&:schedule_min_json) }
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,4 +17,8 @@ class Course < ApplicationRecord
   def display_name
     "#{subject.code}-#{section}"
   end
+
+  def schedule_json
+    { code: display_name, modules: schedule.schedule_events.map(&:schedule_json) }
+  end
 end

--- a/app/models/schedule_event.rb
+++ b/app/models/schedule_event.rb
@@ -7,7 +7,7 @@ class ScheduleEvent < ApplicationRecord
   DAYS = (0..5).to_a.freeze
   MODULES = (0..7).to_a.freeze
 
-  def schedule_json
-    { category: category, day: day, module: self.module }
+  def schedule_min_json
+    { c: category, d: day, m: self.module }
   end
 end

--- a/app/models/schedule_event.rb
+++ b/app/models/schedule_event.rb
@@ -6,4 +6,8 @@ class ScheduleEvent < ApplicationRecord
 
   DAYS = (0..5).to_a.freeze
   MODULES = (0..7).to_a.freeze
+
+  def schedule_json
+    { category: category, day: day, module: self.module }
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,8 @@
     <meta property="og:type" content="website">
     <%= tag.meta property: 'og:url', content: request.host -%>
     <%= tag.meta property: 'og:description', content: yield(:description).empty? ? t('page_description') : yield(:description) -%>
-    <%= tag.meta property: 'og:image', content: asset_path('logo.png') %>
+    <%= tag.meta property: 'flyyer:default', content: asset_path('logo.png') %>
+    <%= display_meta_tags site: 'main' %>
     <!-- TL -->
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,14 +5,7 @@
     <title>UCalendar</title>
     <%= tag.meta name:'description', content: t('page_description') %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <!-- OG -->
-    <meta property="og:title" content="UCalendar">
-    <meta property="og:type" content="website">
-    <%= tag.meta property: 'og:url', content: request.host -%>
-    <%= tag.meta property: 'og:description', content: yield(:description).empty? ? t('page_description') : yield(:description) -%>
-    <%= tag.meta property: 'flyyer:default', content: asset_path('logo.png') %>
-    <%= display_meta_tags site: 'main' %>
-    <!-- TL -->
+    <%= display_meta_tags %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/schedule/show.html.erb
+++ b/app/views/schedule/show.html.erb
@@ -1,7 +1,3 @@
-<% unless @term.nil? || @courses.empty? %>
-  <% provide :description, t('schedule_of', subjects_names: @courses.map(&:subject).map(&:name).to_sentence) %>
-<% end %>
-
 <%= tag.section class: 'schedule-section' do -%>
   <%= tag.div class: 'schedule-card' do -%>
 

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
Usa [flyyer](https://www.flyyer.io/) para la generación de imágenes. 

Incluye una gema de metatags, para utilizar `display_meta_tags` e insertar tags más dinámicamente. Esto se podría cambiar a futuro, eliminando esta gema para insertar los tags de flyyer como se insertan actualmente los tags o remplazando los tags actuales por una llamada a esta función.