### PR TITLE
feat: add exams in ics generation

### DIFF
--- a/app/lib/buscacursos_scraper.rb
+++ b/app/lib/buscacursos_scraper.rb
@@ -40,7 +40,7 @@ class BuscacursosScraper
     url = "#{ENV['BC_HOST']}/MiCalendarioDePruebas.ics.php"
     response = HTTP.cookies("cursosuc-#{year}-#{semester}" => courses_sections.join('%2C')).get(url)
 
-    return [] if response.content_type != 'text/ics'
+    return [] if %w[text/ics application/force-download].include?(response.content_type)
 
     # ! Se usa expresiones regulares ya que el formato del
     # ! archivo retornado por BuscaCursos no es válido como ics


### PR DESCRIPTION
## Descripción

Añade la obtención de pruebas en la generación del horario. No se guardan en la BDD, pero tal vez eso sea ideal, ya que solo se necesita 1 request (que es para solicitar un documento pequeño) y las pruebas no son agregadas junto a los cursos (no es posible saber si un curso tiene pruebas de antemano o si estas cambiaron).

---

fix #8
